### PR TITLE
Add stepTypesToKeep to getThreads()

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -30,6 +30,7 @@ import {
   Prompt,
   Score,
   Step,
+  StepType,
   User,
   Utils
 } from './types';
@@ -776,6 +777,7 @@ export class API {
     before?: Maybe<string>;
     filters?: ThreadsFilter[];
     orderBy?: ThreadsOrderBy;
+    stepTypesToKeep?: StepType[];
   }): Promise<PaginatedResponse<CleanThreadFields>> {
     const query = `
     query GetThreads(
@@ -787,6 +789,7 @@ export class API {
         $first: Int,
         $last: Int,
         $projectId: String,
+        $stepTypesToKeep: [StepType!],
         ) {
         threads(
             after: $after,
@@ -797,6 +800,7 @@ export class API {
             first: $first,
             last: $last,
             projectId: $projectId,
+            stepTypesToKeep: $stepTypesToKeep,
             ) {
             pageInfo {
                 startCursor


### PR DESCRIPTION
Exposed the to keep parameter from https://github.com/Chainlit/chainlit-cloud/pull/435

Only on getThreads, no listThreads() in the TS SDK.
Failure in CI is due to staging not yet up to date.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Chainlit/typescript-client/14)
<!-- Reviewable:end -->
