### PR TITLE
feat: add minimal support for dall-e generation

### DIFF
--- a/tests/integration/openai.test.ts
+++ b/tests/integration/openai.test.ts
@@ -94,4 +94,37 @@ describe.skip('OpenAI Instrumentation', () => {
       })
     );
   });
+
+  it('should monitor image generation', async () => {
+    const spy = jest.spyOn(client.api, 'sendSteps');
+
+    const openai = new OpenAI();
+
+    const response = await openai.images.generate({
+      prompt: 'A painting of a rose in the style of Picasso.',
+      model: 'dall-e-2',
+      size: '256x256',
+      n: 1
+    });
+
+    await client.instrumentation.openai(response);
+
+    expect(response.data[0].url).toBeTruthy();
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'dall-e-2',
+          type: 'run',
+          input: {
+            model: 'dall-e-2',
+            prompt: 'A painting of a rose in the style of Picasso.',
+            size: '256x256',
+            n: 1
+          },
+          output: response
+        })
+      ])
+    );
+  });
 });


### PR DESCRIPTION
<img width="783" alt="image" src="https://github.com/Chainlit/typescript-client/assets/19293395/f6dbb487-a22d-4083-8021-35b0d93bbb81">

https://linear.app/literalai/issue/ENG-1534/as-a-ts-sdk-user-i-can-instrument-on-openai-image-generations

Because it doesn't follow either Chat or Completion generation, I used a step, it will hopefully support the future steps easier.

Also We should probably create attachment for output images ?


Also added minimal tests on openai instrumentation