### PR TITLE
TypeScript SDK - fix: use promptType in datasetitem metadata

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -760,7 +760,7 @@ export class API {
     mutation CreateGeneration($generation: GenerationPayloadInput!) {
       createGeneration(generation: $generation) {
           id,
-          type 
+          type
       }
   }
     `;


### PR DESCRIPTION
Fixes for the migration:
- handle the promptType to remap it to a type
- replace llm to run since we need to pass either messages or prompt for LLM steps

End-to-end tests should pass against the migration branch.