### PR TITLE
fix(deps): relax peer dependency version rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,11 +58,11 @@
     "uuid": "^9.0.1"
   },
   "peerDependencies": {
-    "@ai-sdk/openai": "^0.0.24",
-    "ai": "^3.1.31",
-    "langchain": "^0.1.14",
-    "llamaindex": "^0.3.15",
-    "openai": "^4.42.0",
-    "zod-to-json-schema": "^3.23.0"
+    "@ai-sdk/openai": ">=0.0.24",
+    "ai": ">=3.1.31",
+    "langchain": ">=0.1.14",
+    "llamaindex": ">=0.3.15",
+    "openai": ">=4.42.0",
+    "zod-to-json-schema": ">=3.23.0"
   }
 }


### PR DESCRIPTION
As discussed [on Slack](https://chainlit.slack.com/archives/C0740NK6QN4/p1718209853280289?thread_ts=1718036067.904319&cid=C0740NK6QN4), I wonder if it is legitimate to caret-pin exact versions of the peer dependencies.

This leads to an uncomfortable situation if a peer package has released a new version since the last cut of the TS SDK. For example the latest version of the Vercel AI SDK is 0.0.24 , but the TS SDK had it pinned at 0.0.9. This is solved in v0.0.507 of the SDK but in the meantime it produced NPM errors which are hard to solve : either the user had to downgrade the AI SDK they used, or to `npm install --force` to ignore the error.

IMO it is much more flexible to allow peer dependencies at a known version _or above_. WDYT ?

(btw since i noticed this, AI SDK is now at 0.0.31 so we are back to being incompatible :'( )