### PR TITLE
fix(deps): require correct minor versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,12 +42,12 @@
         "zod-to-json-schema": "^3.23.0"
       },
       "peerDependencies": {
-        "@ai-sdk/openai": ">=0.0.24",
-        "ai": ">=3.1.31",
-        "langchain": ">=0.1.14",
-        "llamaindex": ">=0.3.15",
-        "openai": ">=4.42.0",
-        "zod-to-json-schema": ">=3.23.0"
+        "@ai-sdk/openai": "0.0.x",
+        "ai": "3.x",
+        "langchain": "0.1.x",
+        "llamaindex": "0.3.x",
+        "openai": "4.x",
+        "zod-to-json-schema": "3.x"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -57,11 +57,11 @@
     "uuid": "^9.0.1"
   },
   "peerDependencies": {
-    "@ai-sdk/openai": ">=0.0.24",
-    "ai": ">=3.1.31",
-    "langchain": ">=0.1.14",
-    "llamaindex": ">=0.3.15",
-    "openai": ">=4.42.0",
-    "zod-to-json-schema": ">=3.23.0"
+    "@ai-sdk/openai": "0.0.x",
+    "ai": "3.x",
+    "langchain": "0.1.x",
+    "llamaindex": "0.3.x",
+    "openai": "4.x",
+    "zod-to-json-schema": "3.x"
   }
 }


### PR DESCRIPTION
The change i made earlier introduced some dependency hell that basically affects all of our cookbook projects.

The symptom is that if you try to update the `literalai/client` dependency on any of the projects, you will get an error where it either will refuse to install (because of incompatible peer deps), or gets installed but then crashes on runtime.

I've tested on all typescript cookbooks, and while upgrading to v0.508 doesn't work, upgrading to this version directly works.