### PR TITLE
feat: support root run

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -49,6 +49,7 @@ const version = packageJson.version;
 const stepFields = `
     id
     threadId
+    rootRunId
     parentId
     startTime
     endTime
@@ -152,6 +153,7 @@ function ingestStepsFieldsBuilder(steps: Step[]) {
   for (let id = 0; id < steps.length; id++) {
     generated += `$id_${id}: String!
         $threadId_${id}: String
+        $rootRunId_${id}: String
         $type_${id}: StepType
         $startTime_${id}: DateTime
         $endTime_${id}: DateTime
@@ -177,6 +179,7 @@ function ingestStepsArgsBuilder(steps: Step[]) {
       step${id}: ingestStep(
         id: $id_${id}
         threadId: $threadId_${id}
+        rootRunId: $rootRunId_${id}
         startTime: $startTime_${id}
         endTime: $endTime_${id}
         type: $type_${id}
@@ -1651,6 +1654,7 @@ export class API {
           input
           expectedOutput
           intermediarySteps
+          stepId
         }
       }
     `;
@@ -1676,6 +1680,7 @@ export class API {
           input
           expectedOutput
           intermediarySteps
+          stepId
         }
       }
     `;
@@ -1701,6 +1706,7 @@ export class API {
           input
           expectedOutput
           intermediarySteps
+          stepId
         }
       }
     `;
@@ -1732,6 +1738,7 @@ export class API {
           input
           expectedOutput
           intermediarySteps
+          stepId
         }
       }
     `;
@@ -1767,6 +1774,7 @@ export class API {
           input
           expectedOutput
           intermediarySteps
+          stepId
         }
       }
     `;

--- a/src/evaluation/experiment-item-run.ts
+++ b/src/evaluation/experiment-item-run.ts
@@ -39,7 +39,12 @@ export class ExperimentItemRun extends Step {
       {
         currentThread: currentStore?.currentThread ?? null,
         currentStep: this,
-        currentExperimentItemRunId: this.id ?? null
+        currentExperimentItemRunId: this.id ?? null,
+        rootRun: currentStore?.rootRun
+          ? currentStore?.rootRun
+          : this.type === 'run'
+          ? this
+          : null
       },
       async () => {
         try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ type StoredContext = {
   currentThread: Thread | null;
   currentStep: Step | null;
   currentExperimentItemRunId?: string | null;
+  rootRun: Step | null;
 };
 
 const storage = new AsyncLocalStorage<StoredContext>();
@@ -126,6 +127,16 @@ export class LiteralClient {
   }
 
   /**
+   * Returns the root run from the context or null if none.
+   * @returns The root run, if any.
+   */
+  _rootRun(): Step | null {
+    const store = storage.getStore();
+
+    return store?.rootRun || null;
+  }
+
+  /**
    * Gets the current thread from the context.
    * WARNING : this will throw if run outside of a thread context.
    * @returns The current thread, if any.
@@ -174,5 +185,22 @@ export class LiteralClient {
     }
 
     return store?.currentExperimentItemRunId;
+  }
+
+  /**
+   * Gets the root run from the context.
+   * WARNING : this will throw if run outside of a step context.
+   * @returns The current step, if any.
+   */
+  getRootRun(): Step {
+    const store = storage.getStore();
+
+    if (!store?.rootRun) {
+      throw new Error(
+        'Literal AI SDK : tried to access root run outside of a context.'
+      );
+    }
+
+    return store.rootRun;
   }
 }

--- a/src/observability/step.ts
+++ b/src/observability/step.ts
@@ -23,6 +23,7 @@ class StepFields extends Utils {
   name!: string;
   type!: StepType;
   threadId?: string;
+  rootRunId?: Maybe<string>;
   createdAt?: Maybe<string>;
   startTime?: Maybe<string>;
   id?: Maybe<string>;
@@ -73,9 +74,10 @@ export class Step extends StepFields {
       return;
     }
 
-    // Automatically assign parent thread & step if there are any in the store.
+    // Automatically assign parent thread & step & rootRun if there are any in the store.
     this.threadId = this.threadId ?? this.client._currentThread()?.id;
     this.parentId = this.parentId ?? this.client._currentStep()?.id;
+    this.rootRunId = this.rootRunId ?? this.client._rootRun()?.id;
 
     // Set the creation and start time to the current time if not provided.
     if (!this.createdAt) {
@@ -167,7 +169,12 @@ export class Step extends StepFields {
         currentThread: currentStore?.currentThread ?? null,
         currentExperimentItemRunId:
           currentStore?.currentExperimentItemRunId ?? null,
-        currentStep: this
+        currentStep: this,
+        rootRun: currentStore?.rootRun
+          ? currentStore?.rootRun
+          : this.type === 'run'
+          ? this
+          : null
       },
       () => cb(this)
     );
@@ -197,6 +204,7 @@ export class Step extends StepFields {
       this.scores = updatedStep.scores ?? this.scores;
       this.attachments = updatedStep.attachments ?? this.attachments;
       this.environment = updatedStep.environment ?? this.environment;
+      this.rootRunId = updatedStep.rootRunId ?? this.rootRunId;
     }
 
     this.send().catch(console.error);

--- a/src/observability/thread.ts
+++ b/src/observability/thread.ts
@@ -109,7 +109,8 @@ export class Thread extends ThreadFields {
         currentThread: this,
         currentExperimentItemRunId:
           currentStore?.currentExperimentItemRunId ?? null,
-        currentStep: null
+        currentStep: null,
+        rootRun: null
       },
       () => cb(this)
     );

--- a/tests/wrappers.test.ts
+++ b/tests/wrappers.test.ts
@@ -164,9 +164,9 @@ describe('Wrapper', () => {
 
       await sleep(1000);
       const run = await client.api.getStep(runId!);
-      const retrieveStep = await client.api.getStep(stepId!);
+      const createdStep = await client.api.getStep(stepId!);
 
-      expect(retrieveStep!.rootRunId).toEqual(run!.id);
+      expect(createdStep!.rootRunId).toEqual(run!.id);
     });
 
     it('handles steps outside of a thread', async () => {


### PR DESCRIPTION
## Changes

- Update gql schemas to support root run
- Handle root run context
- Update tests

## How to test?

- Start the local server on `clement/eng-1717-improve-ands-step-association` 
- Run tests `npm run test`
- Notice the steps have a rootRunId in db