### PR TITLE
fix: seeded prompt required test udpate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@literalai/client",
-  "version": "0.0.517",
+  "version": "0.0.518",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@literalai/client",
-      "version": "0.0.517",
+      "version": "0.0.518",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.6.2",


### PR DESCRIPTION
Seeded prompts changed since the A/B testing feature. This required test update.

Tried to have tests rely on version=0 when getting a prompt. 
