### PR TITLE
feat: add release param

### DIFF
--- a/tests/decorate.test.ts
+++ b/tests/decorate.test.ts
@@ -16,14 +16,14 @@ if (!url || !apiKey) {
   throw new Error('Missing environment variables');
 }
 
-const client = new LiteralClient({ apiKey, apiUrl: url });
+const client = new LiteralClient({ apiKey, apiUrl: url, release: 'test' });
 
 describe('Decorator', () => {
   describe('Manual logging', () => {
     it('adds metadata and tags to everything logged inside the wrapper', async () => {
       let threadId: Maybe<string>;
       let stepId: Maybe<string>;
-      const metadata = { key: 'value' };
+      const metadata = { key: 'value', release: 'test' };
       const tags = ['tag1', 'tag2'];
 
       await client.decorate({ metadata, tags }).wrap(async () => {


### PR DESCRIPTION
## Changes

- Handle the `release` param in the sdk

## How to test?

- Initialize a client with the `release: "test"` option
- Log a thread/step
- Notice the logged metadata

![Screenshot 2024-10-15 at 16 27 24](https://github.com/user-attachments/assets/22b1ea72-15b5-4372-9d58-8ebb54ab6c1b)
![Screenshot 2024-10-15 at 16 27 36](https://github.com/user-attachments/assets/0ceb312a-a410-420a-bae3-24f7a24e5f7c)


