### PR TITLE
feat: add code score type

### DIFF
--- a/src/evaluation/score.ts
+++ b/src/evaluation/score.ts
@@ -1,6 +1,6 @@
 import { Maybe, OmitUtils, Utils } from '../utils';
 
-export type ScoreType = 'HUMAN' | 'AI';
+export type ScoreType = 'HUMAN' | 'CODE' | 'AI';
 
 class ScoreFields extends Utils {
   id?: Maybe<string>;


### PR DESCRIPTION
Expose `ScoreType.CODE`.

To be tested with platform containing [this PR](https://github.com/Chainlit/chainlit-cloud/pull/1128).