### PR TITLE
fix: exported classes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@literalai/client",
-  "version": "0.0.602",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@literalai/client",
-      "version": "0.0.602",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,8 +47,10 @@
         "ai": "3.x",
         "langchain": "0.x",
         "llamaindex": "0.3",
-        "openai": "4.x",
         "zod-to-json-schema": "3.x"
+      },
+      "peerDependencies": {
+        "openai": "4.x"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@literalai/client",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "",
   "exports": {
     ".": {

--- a/package.json
+++ b/package.json
@@ -57,13 +57,15 @@
     "mustache": "^4.2.0",
     "uuid": "^9.0.1"
   },
+  "peerDependencies": {
+    "openai": "4.x"
+  },
   "optionalDependencies": {
     "@ai-sdk/openai": "0.0.x",
     "@langchain/openai": "0.x",
     "ai": "3.x",
     "langchain": "0.x",
     "llamaindex": "0.3",
-    "openai": "4.x",
     "zod-to-json-schema": "3.x"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,17 @@ import { Thread, ThreadConstructor } from './observability/thread';
 import { Environment } from './utils';
 
 export * from './utils';
+
+export * from './observability/attachment';
 export * from './observability/generation';
+export * from './observability/step';
+export * from './observability/thread';
+
+export * from './evaluation/dataset';
+export * from './evaluation/score';
+export * from './evaluation/experiment-item-run';
+
+export * from './prompt-engineering/prompt';
 
 export type * from './instrumentation';
 


### PR DESCRIPTION
The cookbook https://github.com/Chainlit/literalai-cookbooks/tree/main/typescript/prompt-iteration-promptfoo uses Dataset, Prompt, so we need to export objects for people to use directly from code.

I bumped to 0.1.1 at the same time